### PR TITLE
Add support for cross-middleware responses.

### DIFF
--- a/src/main/java/pw/mihou/nexus/Nexus.java
+++ b/src/main/java/pw/mihou/nexus/Nexus.java
@@ -8,6 +8,7 @@ import pw.mihou.nexus.core.logger.adapters.NexusLoggingAdapter;
 import pw.mihou.nexus.core.managers.NexusShardManager;
 import pw.mihou.nexus.core.managers.facade.NexusCommandManager;
 import pw.mihou.nexus.features.command.facade.NexusCommand;
+import pw.mihou.nexus.features.command.responders.NexusResponderRepository;
 import pw.mihou.nexus.features.command.synchronizer.NexusSynchronizer;
 import pw.mihou.nexus.features.ratelimiter.facade.NexusRatelimiter;
 
@@ -49,6 +50,15 @@ public interface Nexus extends SlashCommandCreateListener {
      * {@link Nexus} instance.
      */
     NexusSynchronizer getSynchronizer();
+
+    /**
+     * Retrieves the command responder repository that is responsible for
+     * handling cross-middleware and command responders.
+     *
+     * @return  The command responder repository reasonable for this shard's
+     * cross-middleware and command responders.
+     */
+    NexusResponderRepository getResponderRepository();
 
     /**
      * Retrieves the shard manager that is being utilized by

--- a/src/main/java/pw/mihou/nexus/core/NexusCore.java
+++ b/src/main/java/pw/mihou/nexus/core/NexusCore.java
@@ -17,6 +17,7 @@ import pw.mihou.nexus.core.threadpool.NexusThreadPool;
 import pw.mihou.nexus.features.command.core.NexusBaseCommandImplementation;
 import pw.mihou.nexus.features.command.core.NexusCommandCore;
 import pw.mihou.nexus.features.command.facade.NexusCommand;
+import pw.mihou.nexus.features.command.responders.NexusResponderRepository;
 import pw.mihou.nexus.features.command.synchronizer.NexusSynchronizer;
 import pw.mihou.nexus.features.messages.defaults.NexusDefaultMessageConfiguration;
 import pw.mihou.nexus.features.messages.facade.NexusMessageConfiguration;
@@ -40,6 +41,7 @@ public class NexusCore implements Nexus {
     private final NexusConfiguration nexusConfiguration;
     private final NexusEngineX engineX = new NexusEngineXCore(this);
     private final NexusSynchronizer synchronizer = new NexusSynchronizer(this);
+    private final NexusResponderRepository responderRepository = new NexusResponderRepository();
 
     /**
      * Creates a new Nexus Core with a customized {@link NexusMessageConfiguration} and
@@ -70,6 +72,11 @@ public class NexusCore implements Nexus {
     @Override
     public NexusSynchronizer getSynchronizer() {
         return synchronizer;
+    }
+
+    @Override
+    public NexusResponderRepository getResponderRepository() {
+        return responderRepository;
     }
 
     @Override

--- a/src/main/java/pw/mihou/nexus/features/command/core/NexusMiddlewareEventCore.java
+++ b/src/main/java/pw/mihou/nexus/features/command/core/NexusMiddlewareEventCore.java
@@ -1,0 +1,20 @@
+package pw.mihou.nexus.features.command.core;
+
+import org.javacord.api.event.interaction.SlashCommandCreateEvent;
+import pw.mihou.nexus.features.command.facade.NexusCommand;
+import pw.mihou.nexus.features.command.facade.NexusCommandEvent;
+import pw.mihou.nexus.features.command.facade.NexusMiddlewareEvent;
+
+public record NexusMiddlewareEventCore(NexusCommandEvent event) implements NexusMiddlewareEvent {
+
+    @Override
+    public SlashCommandCreateEvent getBaseEvent() {
+        return event.getBaseEvent();
+    }
+
+    @Override
+    public NexusCommand getCommand() {
+        return event.getCommand();
+    }
+
+}

--- a/src/main/java/pw/mihou/nexus/features/command/facade/NexusCommandEvent.java
+++ b/src/main/java/pw/mihou/nexus/features/command/facade/NexusCommandEvent.java
@@ -185,7 +185,9 @@ public interface NexusCommandEvent {
      * @return The {@link InteractionOriginalResponseUpdater}.
      */
     default CompletableFuture<InteractionOriginalResponseUpdater> respondLater() {
-        return getInteraction().respondLater();
+        return getNexus()
+                .getResponderRepository()
+                .get(getBaseEvent().getInteraction());
     }
 
     /**
@@ -195,7 +197,9 @@ public interface NexusCommandEvent {
      * @return The {@link InteractionOriginalResponseUpdater} with the ephemeral flag attached.
      */
     default CompletableFuture<InteractionOriginalResponseUpdater> respondLaterAsEphemeral() {
-        return getInteraction().respondLater(true);
+        return getNexus()
+                .getResponderRepository()
+                .getEphemereal(getBaseEvent().getInteraction());
     }
 
 }

--- a/src/main/java/pw/mihou/nexus/features/command/facade/NexusMiddlewareEvent.java
+++ b/src/main/java/pw/mihou/nexus/features/command/facade/NexusMiddlewareEvent.java
@@ -1,0 +1,52 @@
+package pw.mihou.nexus.features.command.facade;
+
+import pw.mihou.nexus.features.command.interceptors.facades.NexusMiddlewareGate;
+import pw.mihou.nexus.features.messages.facade.NexusMessage;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface NexusMiddlewareEvent extends NexusCommandEvent {
+
+    /**
+     * A middleware-only function that tells Discord that the response will be
+     * taking more than three-seconds because the middleware has to process tasks
+     * that can take more than three-second limit.
+     */
+    default CompletableFuture<Void> askDelayedResponse() {
+            return CompletableFuture.allOf(
+                    getNexus().getResponderRepository().peek(getBaseEvent().getInteraction())
+            );
+    }
+
+    /**
+     * Tells the command interceptor handler to move forward with the next
+     * middleware if there is any, otherwise executes the command code.
+     *
+     * @return  The {@link NexusMiddlewareGate} that should be returned
+     * in the function.
+     */
+    default NexusMiddlewareGate next() {
+        return NexusMiddlewareGate.next();
+    }
+
+    /**
+     * Stops further command execution. This cancels the command from executing
+     * without sending a notice.
+     *
+     * @return The middleware gate to use.
+     */
+    default NexusMiddlewareGate stop() {
+        return NexusMiddlewareGate.stop();
+    }
+
+    /**
+     * Stops further command execution. This cancels the command from executing
+     * and sends a notice to the user.
+     *
+     * @return The middleware gate to use.
+     */
+    default NexusMiddlewareGate stop(NexusMessage response) {
+        return NexusMiddlewareGate.stop(response);
+    }
+
+}

--- a/src/main/java/pw/mihou/nexus/features/command/interceptors/core/NexusCommandInterceptorCore.java
+++ b/src/main/java/pw/mihou/nexus/features/command/interceptors/core/NexusCommandInterceptorCore.java
@@ -1,5 +1,6 @@
 package pw.mihou.nexus.features.command.interceptors.core;
 
+import pw.mihou.nexus.features.command.core.NexusMiddlewareEventCore;
 import pw.mihou.nexus.features.command.facade.NexusCommandEvent;
 import pw.mihou.nexus.features.command.interceptors.facades.NexusAfterware;
 import pw.mihou.nexus.features.command.interceptors.facades.NexusCommandInterceptor;
@@ -50,7 +51,7 @@ public class NexusCommandInterceptorCore {
         }
 
         if (interceptor instanceof NexusMiddleware) {
-            return ((NexusMiddleware) interceptor).onBeforeCommand(event);
+            return ((NexusMiddleware) interceptor).onBeforeCommand(new NexusMiddlewareEventCore(event));
         } else if (interceptor instanceof NexusAfterware){
             ((NexusAfterware) interceptor).onAfterCommandExecution(event);
         }

--- a/src/main/java/pw/mihou/nexus/features/command/interceptors/facades/NexusMiddleware.java
+++ b/src/main/java/pw/mihou/nexus/features/command/interceptors/facades/NexusMiddleware.java
@@ -1,6 +1,6 @@
 package pw.mihou.nexus.features.command.interceptors.facades;
 
-import pw.mihou.nexus.features.command.facade.NexusCommandEvent;
+import pw.mihou.nexus.features.command.facade.NexusMiddlewareEvent;
 
 public interface NexusMiddleware extends NexusCommandInterceptor {
 
@@ -12,6 +12,6 @@ public interface NexusMiddleware extends NexusCommandInterceptor {
      * @param event The event that was received by Nexus.
      * @return A boolean that indicates whether to allow the command to execute any further.
      */
-    NexusMiddlewareGate onBeforeCommand(NexusCommandEvent event);
+    NexusMiddlewareGate onBeforeCommand(NexusMiddlewareEvent event);
 
 }

--- a/src/main/java/pw/mihou/nexus/features/command/interceptors/facades/NexusMiddlewareGate.java
+++ b/src/main/java/pw/mihou/nexus/features/command/interceptors/facades/NexusMiddlewareGate.java
@@ -6,9 +6,11 @@ import pw.mihou.nexus.features.messages.facade.NexusMessage;
 public interface NexusMiddlewareGate {
 
     /**
-     * Allows the command to execute forward.
+     * Tells the command interceptor handler to move forward with the next
+     * middleware if there is any, otherwise executes the command code.
      *
-     * @return The middleware gate to use.
+     * @return  The {@link NexusMiddlewareGate} that should be returned
+     * in the function.
      */
     static NexusMiddlewareGate next() {
         return new NexusMiddlewareGateCore(true, null);

--- a/src/main/java/pw/mihou/nexus/features/command/responders/NexusResponderRepository.java
+++ b/src/main/java/pw/mihou/nexus/features/command/responders/NexusResponderRepository.java
@@ -1,0 +1,69 @@
+package pw.mihou.nexus.features.command.responders;
+
+import org.javacord.api.interaction.Interaction;
+import org.javacord.api.interaction.callback.InteractionOriginalResponseUpdater;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class NexusResponderRepository {
+
+    private final Map<Long, InteractionOriginalResponseUpdater> responders = new ConcurrentHashMap<>();
+
+    /**
+     * Gets the current {@link InteractionOriginalResponseUpdater} for the specific interaction
+     * if available from another middleware otherwise requests for a new {@link InteractionOriginalResponseUpdater}
+     * that can be used instead.
+     * <br><br>
+     * Not to be confused with {@link NexusResponderRepository#get(Interaction)} which deliberately
+     * destroys the interaction that is being stored after being requested. This is intended for middlewares to
+     * prevent Discord's Interaction has failed while processing a heavy task.
+     *
+     * @param interaction   The interaction to reference.
+     * @return              The {@link InteractionOriginalResponseUpdater} if present otherwise requests for one.
+     */
+    public CompletableFuture<InteractionOriginalResponseUpdater> peek(Interaction interaction) {
+        if (responders.containsKey(interaction.getId())) {
+            return CompletableFuture.completedFuture(responders.get(interaction.getId()));
+        }
+
+        return interaction.respondLater()
+                .thenApply(responseUpdater -> responders.put(interaction.getId(), responseUpdater));
+    }
+
+    /**
+     * Gets the current {@link InteractionOriginalResponseUpdater} for the specific interaction if
+     * available from another middleware otherwise requests for a new {@link InteractionOriginalResponseUpdater}
+     * that can be used instead.
+     *
+     * @param interaction   The interaction to reference for.
+     * @return              The {@link InteractionOriginalResponseUpdater} if present otherwise requests for one.
+     */
+    public CompletableFuture<InteractionOriginalResponseUpdater> get(Interaction interaction) {
+        if (responders.containsKey(interaction.getId())) {
+            return CompletableFuture.completedFuture(responders.remove(interaction.getId()));
+        }
+
+        return interaction.respondLater()
+                .thenApply(responseUpdater -> responders.put(interaction.getId(), responseUpdater));
+    }
+
+    /**
+     * Gets the current {@link InteractionOriginalResponseUpdater} for the specific interaction if
+     * available from another middleware otherwise requests for a new {@link InteractionOriginalResponseUpdater}
+     * that can be used instead.
+     *
+     * @param interaction   The interaction to reference for.
+     * @return              The {@link InteractionOriginalResponseUpdater} if present otherwise requests for one.
+     */
+    public CompletableFuture<InteractionOriginalResponseUpdater> getEphemereal(Interaction interaction) {
+        if (responders.containsKey(interaction.getId())) {
+            return CompletableFuture.completedFuture(responders.remove(interaction.getId()));
+        }
+
+        return interaction.respondLater(true)
+                .thenApply(responseUpdater -> responders.put(interaction.getId(), responseUpdater));
+    }
+
+}


### PR DESCRIPTION
Cross-middleware responses have been a known issue with Nexus so far and I think it is best to address this by making an entirely new event dedicated to cross-middleware responses that works by redirecting any methods such as `respondLater` and `respondLaterAsEphemeral` towards a responder repository with an extra method called `askDelayedResponse` in the middleware event to delay responses but not send a response, basically using it for requests an increased time limit from Discord above 3 seconds.