### PR TITLE
Middlewares [NEXT]

### DIFF
--- a/src/main/java/pw/mihou/nexus/features/command/core/NexusBaseCommandImplementation.java
+++ b/src/main/java/pw/mihou/nexus/features/command/core/NexusBaseCommandImplementation.java
@@ -19,9 +19,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
-public class NexusBaseCommandImplementation {
-
-    private final NexusCommandCore instance;
+public record NexusBaseCommandImplementation(NexusCommandCore instance) {
 
     /**
      * Creates a new Base Command instance that is used to handle all the command
@@ -29,8 +27,7 @@ public class NexusBaseCommandImplementation {
      *
      * @param instance The command instance.
      */
-    public NexusBaseCommandImplementation(NexusCommandCore instance) {
-        this.instance = instance;
+    public NexusBaseCommandImplementation {
     }
 
     /**
@@ -38,7 +35,7 @@ public class NexusBaseCommandImplementation {
      * the required permissions.
      *
      * @param server The server instance to use, nullable.
-     * @param user The user instance to use.
+     * @param user   The user instance to use.
      * @return Can the user use this command?
      */
     public boolean applyPermissionRestraint(Server server, User user) {
@@ -51,7 +48,7 @@ public class NexusBaseCommandImplementation {
      * required roles.
      *
      * @param server The server instance to use, nullable.
-     * @param user The user instance to use.
+     * @param user   The user instance to use.
      * @return Can the user use this command?
      */
     public boolean applyRoleRestraints(Server server, User user) {
@@ -86,8 +83,8 @@ public class NexusBaseCommandImplementation {
     /**
      * Applies the rate-limiter.
      *
-     * @param user The user to rate-limit.
-     * @param server The server where the command was executed.
+     * @param user      The user to rate-limit.
+     * @param server    The server where the command was executed.
      * @param onLimited If the user is rate-limited.
      * @param onSuccess If the command can be executed.
      */
@@ -108,9 +105,10 @@ public class NexusBaseCommandImplementation {
 
         NexusMiddlewareGateCore middlewareGate = (NexusMiddlewareGateCore) NexusCommandInterceptorCore.interceptWithMany(middlewares, nexusEvent);
 
-        if (!middlewareGate.isAllowed()) {
-            if (middlewareGate.getResponse() != null) {
-                ((NexusMessageCore) middlewareGate.getResponse())
+        if (middlewareGate != null) {
+            NexusMessageCore middlewareResponse = ((NexusMessageCore) middlewareGate.response());
+            if (middlewareResponse != null) {
+                middlewareResponse
                         .convertTo(nexusEvent.respondNow())
                         .respond()
                         .exceptionally(ExceptionLogger.get());

--- a/src/main/java/pw/mihou/nexus/features/command/core/NexusMiddlewareEventCore.java
+++ b/src/main/java/pw/mihou/nexus/features/command/core/NexusMiddlewareEventCore.java
@@ -16,5 +16,4 @@ public record NexusMiddlewareEventCore(NexusCommandEvent event) implements Nexus
     public NexusCommand getCommand() {
         return event.getCommand();
     }
-
 }

--- a/src/main/java/pw/mihou/nexus/features/command/facade/NexusMiddlewareEvent.java
+++ b/src/main/java/pw/mihou/nexus/features/command/facade/NexusMiddlewareEvent.java
@@ -69,12 +69,9 @@ public interface NexusMiddlewareEvent extends NexusCommandEvent {
      * @param response  The response to send if the evaluation is false.
      */
     default void stopIf(@Nonnull Predicate<Void> predicate, @Nullable NexusMessage response) {
-        if (!predicate.test(null)) {
-            next();
-            return;
+        if (predicate.test(null)) {
+            stop(response);
         }
-
-        stop(response);
     }
 
 

--- a/src/main/java/pw/mihou/nexus/features/command/facade/NexusMiddlewareEvent.java
+++ b/src/main/java/pw/mihou/nexus/features/command/facade/NexusMiddlewareEvent.java
@@ -1,9 +1,12 @@
 package pw.mihou.nexus.features.command.facade;
 
-import pw.mihou.nexus.features.command.interceptors.facades.NexusMiddlewareGate;
+import pw.mihou.nexus.features.command.interceptors.repositories.NexusMiddlewareGateRepository;
 import pw.mihou.nexus.features.messages.facade.NexusMessage;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
 
 public interface NexusMiddlewareEvent extends NexusCommandEvent {
 
@@ -21,32 +24,58 @@ public interface NexusMiddlewareEvent extends NexusCommandEvent {
     /**
      * Tells the command interceptor handler to move forward with the next
      * middleware if there is any, otherwise executes the command code.
-     *
-     * @return  The {@link NexusMiddlewareGate} that should be returned
-     * in the function.
      */
-    default NexusMiddlewareGate next() {
-        return NexusMiddlewareGate.next();
+    default void next() {
+        NexusMiddlewareGateRepository
+                .get(getBaseEvent().getInteraction())
+                .next();
     }
 
     /**
      * Stops further command execution. This cancels the command from executing
      * without sending a notice.
-     *
-     * @return The middleware gate to use.
      */
-    default NexusMiddlewareGate stop() {
-        return NexusMiddlewareGate.stop();
+    default void stop() {
+        stop(null);
     }
 
     /**
      * Stops further command execution. This cancels the command from executing
      * and sends a notice to the user.
-     *
-     * @return The middleware gate to use.
      */
-    default NexusMiddlewareGate stop(NexusMessage response) {
-        return NexusMiddlewareGate.stop(response);
+    default void stop(NexusMessage response) {
+        NexusMiddlewareGateRepository
+                .get(getBaseEvent().getInteraction())
+                .stop(response);
     }
+
+    /**
+     * Stops further command execution if the predicate returns a value
+     * of {@link Boolean#TRUE} and allows execution if the predicate is a
+     * {@link Boolean#FALSE}.
+     *
+     * @param predicate The predicate to evaluate.
+     */
+    default void stopIf(@Nonnull Predicate<Void> predicate) {
+        stopIf(predicate, null);
+    }
+
+    /**
+     * Stops further command execution if the predicate returns a value
+     * of {@link Boolean#TRUE} and allows execution if the predicate is a
+     * {@link Boolean#FALSE}.
+     *
+     * @param predicate The predicate to evaluate.
+     * @param response  The response to send if the evaluation is false.
+     */
+    default void stopIf(@Nonnull Predicate<Void> predicate, @Nullable NexusMessage response) {
+        if (!predicate.test(null)) {
+            next();
+            return;
+        }
+
+        stop(response);
+    }
+
 
 }

--- a/src/main/java/pw/mihou/nexus/features/command/facade/NexusMiddlewareEvent.java
+++ b/src/main/java/pw/mihou/nexus/features/command/facade/NexusMiddlewareEvent.java
@@ -55,6 +55,31 @@ public interface NexusMiddlewareEvent extends NexusCommandEvent {
      * {@link Boolean#FALSE}.
      *
      * @param predicate The predicate to evaluate.
+     * @param response  The response to send if the evaluation is false.
+     */
+    default void stopIf(boolean predicate, NexusMessage response) {
+        if (predicate) {
+            stop(response);
+        }
+    }
+
+    /**
+     * Stops further command execution if the predicate returns a value
+     * of {@link Boolean#TRUE} and allows execution if the predicate is a
+     * {@link Boolean#FALSE}.
+     *
+     * @param predicate The predicate to evaluate.
+     */
+    default void stopIf(boolean predicate) {
+        stopIf(predicate, null);
+    }
+
+    /**
+     * Stops further command execution if the predicate returns a value
+     * of {@link Boolean#TRUE} and allows execution if the predicate is a
+     * {@link Boolean#FALSE}.
+     *
+     * @param predicate The predicate to evaluate.
      */
     default void stopIf(@Nonnull Predicate<Void> predicate) {
         stopIf(predicate, null);
@@ -69,9 +94,7 @@ public interface NexusMiddlewareEvent extends NexusCommandEvent {
      * @param response  The response to send if the evaluation is false.
      */
     default void stopIf(@Nonnull Predicate<Void> predicate, @Nullable NexusMessage response) {
-        if (predicate.test(null)) {
-            stop(response);
-        }
+        stopIf(predicate.test(null), response);
     }
 
 

--- a/src/main/java/pw/mihou/nexus/features/command/facade/NexusMiddlewareEvent.java
+++ b/src/main/java/pw/mihou/nexus/features/command/facade/NexusMiddlewareEvent.java
@@ -57,7 +57,7 @@ public interface NexusMiddlewareEvent extends NexusCommandEvent {
      * @param predicate The predicate to evaluate.
      * @param response  The response to send if the evaluation is false.
      */
-    default void stopIf(boolean predicate, NexusMessage response) {
+    default void stopIf(boolean predicate, @Nullable NexusMessage response) {
         if (predicate) {
             stop(response);
         }

--- a/src/main/java/pw/mihou/nexus/features/command/interceptors/commons/NexusCommonInterceptors.java
+++ b/src/main/java/pw/mihou/nexus/features/command/interceptors/commons/NexusCommonInterceptors.java
@@ -18,17 +18,17 @@ public class NexusCommonInterceptors {
 
     static {
         addMiddleware(NEXUS_AUTH_BOT_OWNER_MIDDLEWARE, event -> event.stopIf(
-                unused -> !event.getUser().isBotOwner(),
+                !event.getUser().isBotOwner(),
                 NexusMessage.fromEphemereal("**PERMISSION DENIED**\nYou need to be the bot owner to execute this command.")
         ));
 
         addMiddleware(NEXUS_AUTH_SERVER_OWNER_MIDDLEWARE, event -> event.stopIf(
-                unused -> event.getServer().isPresent() && event.getServer().get().isOwner(event.getUser()),
+                event.getServer().isPresent() && event.getServer().get().isOwner(event.getUser()),
                 NexusMessage.fromEphemereal("**PERMISSION DENIED**\nYou need to be the server owner to execute this command.")
         ));
 
-        addMiddleware(NEXUS_GATE_SERVER, event -> event.stopIf(unused -> event.getServer().isEmpty()));
-        addMiddleware(NEXUS_GATE_DMS, event -> event.stopIf(unused -> event.getServer().isPresent()));
+        addMiddleware(NEXUS_GATE_SERVER, event -> event.stopIf(event.getServer().isEmpty()));
+        addMiddleware(NEXUS_GATE_DMS, event -> event.stopIf(event.getServer().isPresent()));
     }
 
 }

--- a/src/main/java/pw/mihou/nexus/features/command/interceptors/commons/NexusCommonInterceptors.java
+++ b/src/main/java/pw/mihou/nexus/features/command/interceptors/commons/NexusCommonInterceptors.java
@@ -1,7 +1,5 @@
 package pw.mihou.nexus.features.command.interceptors.commons;
 
-import org.javacord.api.interaction.callback.InteractionCallbackDataFlag;
-import pw.mihou.nexus.features.command.interceptors.facades.NexusMiddlewareGate;
 import pw.mihou.nexus.features.messages.facade.NexusMessage;
 
 import static pw.mihou.nexus.features.command.interceptors.facades.NexusCommandInterceptor.addMiddleware;
@@ -19,27 +17,18 @@ public class NexusCommonInterceptors {
     private static final String NEXUS_GATE_DMS = "nexus.gate.dms";
 
     static {
-        addMiddleware(NEXUS_AUTH_BOT_OWNER_MIDDLEWARE, event ->
-                event.getUser().isBotOwner() ?
-                        NexusMiddlewareGate.next() : NexusMiddlewareGate.stop(
-                        NexusMessage.fromWith(
-                                "**PERMISSION DENIED**\nYou need to be the bot owner to execute this command.",
-                                builder -> builder.setFlags(InteractionCallbackDataFlag.EPHEMERAL)
-                        )
-                )
-        );
+        addMiddleware(NEXUS_AUTH_BOT_OWNER_MIDDLEWARE, event -> event.stopIf(
+                unused -> !event.getUser().isBotOwner(),
+                NexusMessage.fromEphemereal("**PERMISSION DENIED**\nYou need to be the bot owner to execute this command.")
+        ));
 
-        addMiddleware(NEXUS_AUTH_SERVER_OWNER_MIDDLEWARE, event ->
-                (event.getServer().isPresent() && event.getServer().get().isOwner(event.getUser())) ?
-                        NexusMiddlewareGate.next() : NexusMiddlewareGate.stop(
-                                NexusMessage.fromWith(
-                                        "**PERMISSION DENIED**\nYou need to be the server owner to execute this command.",
-                                        builder -> builder.setFlags(InteractionCallbackDataFlag.EPHEMERAL)
-                                )
-                )
-        );
-        addMiddleware(NEXUS_GATE_SERVER, event -> event.getServer().isPresent() ? NexusMiddlewareGate.next() : NexusMiddlewareGate.stop());
-        addMiddleware(NEXUS_GATE_DMS, event -> event.getServer().isEmpty() ? NexusMiddlewareGate.next() : NexusMiddlewareGate.stop());
+        addMiddleware(NEXUS_AUTH_SERVER_OWNER_MIDDLEWARE, event -> event.stopIf(
+                unused -> event.getServer().isPresent() && event.getServer().get().isOwner(event.getUser()),
+                NexusMessage.fromEphemereal("**PERMISSION DENIED**\nYou need to be the server owner to execute this command.")
+        ));
+
+        addMiddleware(NEXUS_GATE_SERVER, event -> event.stopIf(unused -> event.getServer().isEmpty()));
+        addMiddleware(NEXUS_GATE_DMS, event -> event.stopIf(unused -> event.getServer().isPresent()));
     }
 
 }

--- a/src/main/java/pw/mihou/nexus/features/command/interceptors/core/NexusCommandInterceptorCore.java
+++ b/src/main/java/pw/mihou/nexus/features/command/interceptors/core/NexusCommandInterceptorCore.java
@@ -71,10 +71,12 @@ public class NexusCommandInterceptorCore {
         for (String name : names) {
             interceptWith(name, event);
             if (!gate.allowed()) {
+                NexusMiddlewareGateRepository.release(event.getBaseEvent().getInteraction());
                 return gate;
             }
         }
 
+        NexusMiddlewareGateRepository.release(event.getBaseEvent().getInteraction());
         return null;
     }
 

--- a/src/main/java/pw/mihou/nexus/features/command/interceptors/core/NexusCommandInterceptorCore.java
+++ b/src/main/java/pw/mihou/nexus/features/command/interceptors/core/NexusCommandInterceptorCore.java
@@ -6,6 +6,7 @@ import pw.mihou.nexus.features.command.interceptors.facades.NexusAfterware;
 import pw.mihou.nexus.features.command.interceptors.facades.NexusCommandInterceptor;
 import pw.mihou.nexus.features.command.interceptors.facades.NexusMiddleware;
 import pw.mihou.nexus.features.command.interceptors.facades.NexusMiddlewareGate;
+import pw.mihou.nexus.features.command.interceptors.repositories.NexusMiddlewareGateRepository;
 
 import java.util.HashMap;
 import java.util.List;
@@ -41,22 +42,19 @@ public class NexusCommandInterceptorCore {
      *
      * @param name The name of the command interceptor.
      * @param event The event being intercepted.
-     * @return Is the command allowed to execute further?
      */
-    private static NexusMiddlewareGate interceptWith(String name, NexusCommandEvent event) {
+    private static void interceptWith(String name, NexusCommandEvent event) {
         NexusCommandInterceptor interceptor = interceptors.getOrDefault(name, null);
 
         if (interceptor == null) {
-            return NexusMiddlewareGate.next();
+            return;
         }
 
         if (interceptor instanceof NexusMiddleware) {
-            return ((NexusMiddleware) interceptor).onBeforeCommand(new NexusMiddlewareEventCore(event));
+            ((NexusMiddleware) interceptor).onBeforeCommand(new NexusMiddlewareEventCore(event));
         } else if (interceptor instanceof NexusAfterware){
             ((NexusAfterware) interceptor).onAfterCommandExecution(event);
         }
-
-        return NexusMiddlewareGate.next();
     }
 
     /**
@@ -69,14 +67,15 @@ public class NexusCommandInterceptorCore {
      */
     public static NexusMiddlewareGate interceptWithMany(List<String> names, NexusCommandEvent event) {
         // This is intentionally a for-loop since we want to stop at a specific point.
+        NexusMiddlewareGateCore gate = NexusMiddlewareGateRepository.get(event.getBaseEvent().getInteraction());
         for (String name : names) {
-            NexusMiddlewareGate gate = interceptWith(name, event);
-            if (!((NexusMiddlewareGateCore) gate).isAllowed()) {
+            interceptWith(name, event);
+            if (!gate.allowed()) {
                 return gate;
             }
         }
 
-        return NexusMiddlewareGate.next();
+        return null;
     }
 
 }

--- a/src/main/java/pw/mihou/nexus/features/command/interceptors/core/NexusMiddlewareGateCore.java
+++ b/src/main/java/pw/mihou/nexus/features/command/interceptors/core/NexusMiddlewareGateCore.java
@@ -3,20 +3,34 @@ package pw.mihou.nexus.features.command.interceptors.core;
 import pw.mihou.nexus.features.command.interceptors.facades.NexusMiddlewareGate;
 import pw.mihou.nexus.features.messages.facade.NexusMessage;
 
+import javax.annotation.Nullable;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
 public class NexusMiddlewareGateCore implements NexusMiddlewareGate {
 
-    private final boolean state;
-    private final NexusMessage response;
+    private final AtomicBoolean state = new AtomicBoolean(true);
+    private final AtomicReference<NexusMessage> response = new AtomicReference<>(null);
 
     /**
-     * Creates a new Nexus Middleware Gate.
+     * Sets the state for this middleware.
      *
-     * @param state The state response of the gate.
-     * @param response The text response of the gate.
+     * @param next  Should the event be allowed to go next?
      */
-    public NexusMiddlewareGateCore(boolean state, NexusMessage response) {
-        this.state = state;
-        this.response = response;
+    private void setState(boolean next) {
+        state.set(next);
+    }
+
+    /**
+     * Sets the response for this middleware gate. This assumes that the middleware
+     * will be rejected since a response can only be set when a middleware rejects
+     * an event.
+     *
+     * @param response  The response to send to the end-user.
+     */
+    private void setResponse(@Nullable NexusMessage response) {
+        setState(false);
+        this.response.set(response);
     }
 
     /**
@@ -24,8 +38,23 @@ public class NexusMiddlewareGateCore implements NexusMiddlewareGate {
      *
      * @return Is the command allowed to execute any further?
      */
-    public boolean isAllowed() {
-        return state;
+    public boolean allowed() {
+        return state.get();
+    }
+
+    @Override
+    public void next() {
+        setState(true);
+    }
+
+    @Override
+    public void stop(@Nullable NexusMessage response) {
+        setResponse(response);
+    }
+
+    @Override
+    public void stop() {
+        setState(false);
     }
 
     /**
@@ -33,7 +62,8 @@ public class NexusMiddlewareGateCore implements NexusMiddlewareGate {
      *
      * @return The response of the middleware, this can be null.
      */
-    public NexusMessage getResponse() {
-        return response;
+    @Nullable
+    public NexusMessage response() {
+        return response.get();
     }
 }

--- a/src/main/java/pw/mihou/nexus/features/command/interceptors/facades/NexusMiddleware.java
+++ b/src/main/java/pw/mihou/nexus/features/command/interceptors/facades/NexusMiddleware.java
@@ -1,17 +1,17 @@
 package pw.mihou.nexus.features.command.interceptors.facades;
 
 import pw.mihou.nexus.features.command.facade.NexusMiddlewareEvent;
+import pw.mihou.nexus.features.messages.facade.NexusMessage;
 
 public interface NexusMiddleware extends NexusCommandInterceptor {
 
     /**
      * This is executed before the rate-limiter which is always before the command execution.
-     * You can prevent further execution by returning a false as a value otherwise allow execution with
-     * a true value.
+     * You can prevent further execution by using {@link NexusMiddlewareEvent#stop(NexusMessage)} or
+     * {@link NexusMiddlewareEvent#stop()}, by default, it will always be using the {@link NexusMiddlewareGate#next()}.
      *
      * @param event The event that was received by Nexus.
-     * @return A boolean that indicates whether to allow the command to execute any further.
      */
-    NexusMiddlewareGate onBeforeCommand(NexusMiddlewareEvent event);
+    void onBeforeCommand(NexusMiddlewareEvent event);
 
 }

--- a/src/main/java/pw/mihou/nexus/features/command/interceptors/facades/NexusMiddlewareGate.java
+++ b/src/main/java/pw/mihou/nexus/features/command/interceptors/facades/NexusMiddlewareGate.java
@@ -1,39 +1,27 @@
 package pw.mihou.nexus.features.command.interceptors.facades;
 
-import pw.mihou.nexus.features.command.interceptors.core.NexusMiddlewareGateCore;
 import pw.mihou.nexus.features.messages.facade.NexusMessage;
+
+import javax.annotation.Nullable;
 
 public interface NexusMiddlewareGate {
 
     /**
      * Tells the command interceptor handler to move forward with the next
      * middleware if there is any, otherwise executes the command code.
-     *
-     * @return  The {@link NexusMiddlewareGate} that should be returned
-     * in the function.
      */
-    static NexusMiddlewareGate next() {
-        return new NexusMiddlewareGateCore(true, null);
-    }
+    void next();
 
     /**
      * Stops further command execution. This cancels the command from executing
      * and sends a notice to the user.
-     *
-     * @return The middleware gate to use.
      */
-    static NexusMiddlewareGate stop(NexusMessage response) {
-        return new NexusMiddlewareGateCore(false, response);
-    }
+    void stop(@Nullable NexusMessage response);
 
     /**
      * Stops further command execution. This cancels the command from executing
      * without sending a notice.
-     *
-     * @return The middleware gate to use.
      */
-    static NexusMiddlewareGate stop() {
-        return stop(null);
-    }
+    void stop();
 
 }

--- a/src/main/java/pw/mihou/nexus/features/command/interceptors/repositories/NexusMiddlewareGateRepository.java
+++ b/src/main/java/pw/mihou/nexus/features/command/interceptors/repositories/NexusMiddlewareGateRepository.java
@@ -1,0 +1,39 @@
+package pw.mihou.nexus.features.command.interceptors.repositories;
+
+import org.javacord.api.interaction.Interaction;
+import pw.mihou.nexus.features.command.interceptors.core.NexusMiddlewareGateCore;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class NexusMiddlewareGateRepository {
+
+    private static final Map<Long, NexusMiddlewareGateCore> gates = new ConcurrentHashMap<>();
+
+    /**
+     * Releases the {@link NexusMiddlewareGateCore} associated with the
+     * interaction.
+     *
+     * @param interaction   The interaction whose {@link NexusMiddlewareGateCore} should
+     *                      be released.
+     */
+    public static void release(Interaction interaction) {
+        gates.remove(interaction.getId());
+    }
+
+    /**
+     * Gets the {@link NexusMiddlewareGateCore} associated with the interaction.
+     *
+     * @param interaction   The interaction to reference from.
+     * @return              The {@link NexusMiddlewareGateCore} associated with this
+     * specific interaction.
+     */
+    public static NexusMiddlewareGateCore get(Interaction interaction) {
+        if (gates.containsKey(interaction.getId())) {
+            return gates.get(interaction.getId());
+        }
+
+        return gates.put(interaction.getId(), new NexusMiddlewareGateCore());
+    }
+
+}

--- a/src/main/java/pw/mihou/nexus/features/command/interceptors/repositories/NexusMiddlewareGateRepository.java
+++ b/src/main/java/pw/mihou/nexus/features/command/interceptors/repositories/NexusMiddlewareGateRepository.java
@@ -29,11 +29,11 @@ public class NexusMiddlewareGateRepository {
      * specific interaction.
      */
     public static NexusMiddlewareGateCore get(Interaction interaction) {
-        if (gates.containsKey(interaction.getId())) {
-            return gates.get(interaction.getId());
+        if (!gates.containsKey(interaction.getId())) {
+            gates.put(interaction.getId(), new NexusMiddlewareGateCore());
         }
 
-        return gates.put(interaction.getId(), new NexusMiddlewareGateCore());
+        return gates.get(interaction.getId());
     }
 
 }


### PR DESCRIPTION
An improved variant of the middleware system that promises the following changes:
- [x] More verbose and readable middleware one-liners with `stopif(...)` methods.
- [x] Return statements are no longer needed for middleware gates.
- [x] Automatically defaults to `next()` for middleware that does not send a signal.
- [x] Supports cross-middleware responses from PR #1.
- [x] Supports expanded Nexus Message interface from PR #2.

Breaking changes of this change includes:
- ⚔️  This change is breaking to middleware that implements the `NexusMiddleware` interface which moved the return type of the function from `NexusMiddlewareGate` to `void` in order to support no.1 and no.2 checkmarks.

- ⚔️   This change also removes the static methods `NexusMiddlewareGate#next` `NexusMiddlewareGate#stop(...)` in favour of the local middleware event methods `NexusMiddlewareEvent#next` and `NexusMiddlewareEvent#stop(...)` or `NexusMiddlewareEvent#stopIf(...)`.

## 💭 How does this improve code-readability?
This patch forces a code-style improvement by disallowing conditional return statements in favor of the method `event.stopIf(...)` which makes code more verbose and cleaner to look at. In addition, the code doesn't require any return statements which means any simple one-line middleware can be one-line without the need for a return statement.

Code examples of how this improves code-readability, referenced from [NexusCommonInterceptors](https://github.com/ShindouMihou/Nexus/blob/master/src/main/java/pw/mihou/nexus/features/command/interceptors/commons/NexusCommonInterceptors.java) of both versions:

### Before
```java
addMiddleware(NEXUS_AUTH_BOT_OWNER_MIDDLEWARE, event ->
                event.getUser().isBotOwner() ?
                        NexusMiddlewareGate.next() : NexusMiddlewareGate.stop(
                        NexusMessage.fromWith(
                                "**PERMISSION DENIED**\nYou need to be the bot owner to execute this command.",
                                builder -> builder.setFlags(InteractionCallbackDataFlag.EPHEMERAL)
                        )
                )
);
```

### After
```java
addMiddleware(NEXUS_AUTH_BOT_OWNER_MIDDLEWARE, event -> event.stopIf(
            !event.getUser().isBotOwner(),
            NexusMessage.fromEphemereal("**PERMISSION DENIED**\nYou need to be the bot owner to execute this command.")
));
```

### Before
```java
addMiddleware(NEXUS_GATE_SERVER, event -> event.getServer().isPresent() ? NexusMiddlewareGate.next() : NexusMiddlewareGate.stop());
```

### After
```java
addMiddleware(NEXUS_GATE_SERVER, event -> event.stopIf(event.getServer().isEmpty()));
```

## 💭 What about if I don't use the stop if method, how do I stop the command from executing?
You can use the method `event.stop()` or `event.stop(NexusMessage)` to tell Nexus to stop the event from executing, this happens immediately after the middleware finishes. It is recommended to not put any `event.next()` function when no longer needed, for instance:

```java
addMIddleware("nexus.auth.server", event -> {
    if (event.getServer().isEmpty()) {
       event.stop();
    }
});
```

The middleware will default to `next()` even if you don't include the method to reduce code, although the above code should use the `event.stopIf(...)` which aims to reduce lines of code.