### PR TITLE
Adds compatiability for v3.5.1 of Javacord

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>org.javacord</groupId>
             <artifactId>javacord</artifactId>
-            <version>3.5.0</version>
+            <version>3.5.1-SNAPSHOT</version>
             <type>pom</type>
         </dependency>
         <dependency>

--- a/src/main/java/pw/mihou/nexus/features/command/synchronizer/overwrites/defaults/NexusDefaultSynchronizeMethods.java
+++ b/src/main/java/pw/mihou/nexus/features/command/synchronizer/overwrites/defaults/NexusDefaultSynchronizeMethods.java
@@ -10,6 +10,7 @@ import pw.mihou.nexus.features.command.synchronizer.overwrites.NexusSynchronizeM
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 public class NexusDefaultSynchronizeMethods implements NexusSynchronizeMethods {
@@ -18,7 +19,7 @@ public class NexusDefaultSynchronizeMethods implements NexusSynchronizeMethods {
     public CompletableFuture<Void> bulkOverwriteGlobal(DiscordApi shard, List<SlashCommandBuilder> slashCommands) {
         CompletableFuture<Void> globalFuture = new CompletableFuture<>();
 
-        shard.bulkOverwriteGlobalApplicationCommands(slashCommands).thenAccept(applicationCommands -> {
+        shard.bulkOverwriteGlobalApplicationCommands(Set.copyOf(slashCommands)).thenAccept(applicationCommands -> {
             NexusCore.logger.debug("Global commands completed synchronization. [size={}]", applicationCommands.size());
             globalFuture.complete(null);
         }).exceptionally(throwable -> {
@@ -43,7 +44,7 @@ public class NexusDefaultSynchronizeMethods implements NexusSynchronizeMethods {
         }
 
         Server server = shard.getServerById(serverId).orElseThrow();
-        shard.bulkOverwriteServerApplicationCommands(server, slashCommands)
+        shard.bulkOverwriteServerApplicationCommands(server, Set.copyOf(slashCommands))
                 .thenAccept(applicationCommands -> {
                     NexusCore.logger.debug("A server has completed synchronization. [server={}, size={}]", serverId, applicationCommands.size());
                     future.complete(null);
@@ -94,7 +95,7 @@ public class NexusDefaultSynchronizeMethods implements NexusSynchronizeMethods {
         }
 
         Server server = api.getServerById(serverId).orElseThrow();
-        List<SlashCommand> commands = server.getSlashCommands().join();
+        Set<SlashCommand> commands = server.getSlashCommands().join();
 
         Optional<SlashCommand> matchingCommand = commands.stream()
                 .filter(slashCommand -> slashCommand.getName().equalsIgnoreCase(command.getName()))


### PR DESCRIPTION
> **Warning!**
> 
> This PR is tracking Javacord and will be kept up-to-date as much as possible to comply with 
> any breaking changes from Javacord.
> 
> You are free to use this PR by checking Jitpack and getting the commit you want from the v3.5.1-COMPATIABILITY branch.

This PR aims to add full compatibility for v3.5.1 of Javacord which will be the next release of Javacord. Currently, this new version performs the following breaking change:
- Changes the return type of collections (breaks Nexus' DefaultSynchronizeMethod which is fixed in this PR).