### PR TITLE
Global and Local Inheritance

### DIFF
--- a/src/main/java/pw/mihou/nexus/configuration/modules/NexusGlobalConfiguration.kt
+++ b/src/main/java/pw/mihou/nexus/configuration/modules/NexusGlobalConfiguration.kt
@@ -32,4 +32,12 @@ class NexusGlobalConfiguration internal constructor() {
      * if you are using a Log4j logger but with a SLF4J bridge as the default logging adapter uses SLF4J.
      */
     @Volatile var logger: NexusLoggingAdapter = NexusDefaultLoggingAdapter()
+
+    /**
+     * To enable global inheritance, wherein all the commands inherits properties from the class provided below, you can
+     * specify which class you want to be inherited and Nexus will take care of inheriting them. Including a global inheritance
+     * class would mean the properties of the global inheritance class will be inherited by children commands regardless of
+     * whether they have a local inheritance class.
+     */
+    @JvmField @Volatile var inheritance: Any? = null
 }

--- a/src/main/java/pw/mihou/nexus/core/exceptions/NotInheritableException.kt
+++ b/src/main/java/pw/mihou/nexus/core/exceptions/NotInheritableException.kt
@@ -1,0 +1,6 @@
+package pw.mihou.nexus.core.exceptions
+
+import java.lang.RuntimeException
+
+class NotInheritableException(clazz: Class<*>):
+    RuntimeException("${clazz.name} is not an inheritable class, ensure that there is at least one empty constructor, or no constructors at all.")

--- a/src/main/java/pw/mihou/nexus/core/reflective/core/NexusReflectiveVariableCore.java
+++ b/src/main/java/pw/mihou/nexus/core/reflective/core/NexusReflectiveVariableCore.java
@@ -59,8 +59,10 @@ public class NexusReflectiveVariableCore implements NexusReflectiveVariableFacad
                         throw new NotInheritableException(parent);
                     }
 
+                    constructor.setAccessible(true);
                     inheritanceReference = constructor.newInstance();
                 } else {
+                    parent.getDeclaredConstructor().setAccessible(true);
                     inheritanceReference = parent.getDeclaredConstructor().newInstance();
                 }
 

--- a/src/main/java/pw/mihou/nexus/core/reflective/core/NexusReflectiveVariableCore.java
+++ b/src/main/java/pw/mihou/nexus/core/reflective/core/NexusReflectiveVariableCore.java
@@ -49,8 +49,9 @@ public class NexusReflectiveVariableCore implements NexusReflectiveVariableFacad
             try {
                 Object inheritanceReference;
 
+                Constructor<?> constructor;
                 if (parent.getConstructors().length != 0) {
-                    Constructor<?> constructor = Arrays.stream(parent.getConstructors())
+                    constructor = Arrays.stream(parent.getConstructors())
                             .filter(construct -> construct.getParameterCount() == 0)
                             .findFirst()
                             .orElse(null);
@@ -59,12 +60,12 @@ public class NexusReflectiveVariableCore implements NexusReflectiveVariableFacad
                         throw new NotInheritableException(parent);
                     }
 
-                    constructor.setAccessible(true);
-                    inheritanceReference = constructor.newInstance();
                 } else {
-                    parent.getDeclaredConstructor().setAccessible(true);
-                    inheritanceReference = parent.getDeclaredConstructor().newInstance();
+                    constructor = parent.getDeclaredConstructor();
                 }
+
+                constructor.setAccessible(true);
+                inheritanceReference = constructor.newInstance();
 
                 prepareInheritance(parent, object, inheritanceReference);
             } catch (InvocationTargetException | InstantiationException | IllegalAccessException |

--- a/src/main/java/pw/mihou/nexus/core/reflective/core/NexusReflectiveVariableCore.java
+++ b/src/main/java/pw/mihou/nexus/core/reflective/core/NexusReflectiveVariableCore.java
@@ -1,12 +1,16 @@
 package pw.mihou.nexus.core.reflective.core;
 
+import pw.mihou.nexus.core.exceptions.NotInheritableException;
 import pw.mihou.nexus.core.reflective.annotations.Required;
 import pw.mihou.nexus.core.reflective.annotations.Share;
 import pw.mihou.nexus.core.reflective.annotations.WithDefault;
 import pw.mihou.nexus.core.reflective.facade.NexusReflectiveVariableFacade;
 import pw.mihou.nexus.features.command.core.NexusCommandCore;
+import pw.mihou.nexus.features.inheritance.Inherits;
 
 import javax.annotation.Nullable;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
 public class NexusReflectiveVariableCore implements NexusReflectiveVariableFacade {
@@ -15,9 +19,9 @@ public class NexusReflectiveVariableCore implements NexusReflectiveVariableFacad
     private final HashMap<String, Object> sharedFields = new HashMap<>();
 
     public NexusReflectiveVariableCore(Object object, NexusCommandCore core) {
-            // We'll collect all the fields with the WithDefault annotation from the reference class first.
-            // then utilize those fields when we need a default value. Please ensure that the field always
-            // has a value beforehand.
+        // We'll collect all the fields with the WithDefault annotation from the reference class first.
+        // then utilize those fields when we need a default value. Please ensure that the field always
+        // has a value beforehand.
 
         Arrays.stream(NexusCommandCore.class.getDeclaredFields())
                 .filter(field -> field.isAnnotationPresent(WithDefault.class))
@@ -32,6 +36,34 @@ public class NexusReflectiveVariableCore implements NexusReflectiveVariableFacad
                         );
                     }
                 });
+
+        if (object.getClass().isAnnotationPresent(Inherits.class)) {
+            Class<?> parent = object.getClass().getAnnotation(Inherits.class).value();
+            Constructor<?> constructor = Arrays.stream(parent.getConstructors())
+                    .filter(construct -> construct.getParameterCount() == 0)
+                    .findFirst()
+                    .orElse(null);
+
+            if (constructor == null) {
+                throw new NotInheritableException(parent);
+            }
+
+            try {
+                Object inheritanceReference = constructor.newInstance();
+                Arrays.stream(parent.getDeclaredFields())
+                        .forEach(field -> {
+                            field.setAccessible(true);
+                            try {
+                                fields.put(field.getName().toLowerCase(), field.get(inheritanceReference));
+                            } catch (IllegalAccessException e) {
+                                e.printStackTrace();
+                                throw new IllegalStateException("Nexus was unable to complete variable inheritance stage for class: " + object.getClass().getName());
+                            }
+                        });
+            } catch (InvocationTargetException | InstantiationException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
 
         // After collecting all the defaults, we can start bootstrapping the fields HashMap.
         Arrays.stream(object.getClass().getDeclaredFields()).forEach(field -> {

--- a/src/main/java/pw/mihou/nexus/features/inheritance/Inherits.java
+++ b/src/main/java/pw/mihou/nexus/features/inheritance/Inherits.java
@@ -1,0 +1,12 @@
+package pw.mihou.nexus.features.inheritance;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Inherits {
+    Class<?> value();
+}

--- a/src/test/java/commands/FilledRequiredTestCommand.java
+++ b/src/test/java/commands/FilledRequiredTestCommand.java
@@ -2,7 +2,6 @@ package commands;
 
 import pw.mihou.nexus.features.command.facade.NexusCommandEvent;
 import pw.mihou.nexus.features.command.facade.NexusHandler;
-import pw.mihou.nexus.features.inheritance.Inherits;
 
 public class FilledRequiredTestCommand implements NexusHandler {
 

--- a/src/test/java/commands/FilledRequiredTestCommand.java
+++ b/src/test/java/commands/FilledRequiredTestCommand.java
@@ -2,6 +2,7 @@ package commands;
 
 import pw.mihou.nexus.features.command.facade.NexusCommandEvent;
 import pw.mihou.nexus.features.command.facade.NexusHandler;
+import pw.mihou.nexus.features.inheritance.Inherits;
 
 public class FilledRequiredTestCommand implements NexusHandler {
 


### PR DESCRIPTION
Adds support for global and local inheritance which will help reduce code duplication by enabling commands to inherit properties from a parent, for example, when you want all commands to be disabled in private messages then you can just write up a global command properties such as:
```kotlin
object GlobalCommandProperties {
   val enabledInDms = false;
}
```

And add the following line to your configuration:
```kotlin
Nexus.configure {
    this.global.inheritance = GlobalCommandProperties
}
```

All commands should then inherit the `enabledInDms` property.

This also includes support for `@Share` properties which will allow interceptors (middlewares, afterware) to be able to access the property. You can also write up the inheritance to only a specific command by including the `@Inherits` annotation, such as example:
```kotlin
@Inherits(GlobalCommandProperties::class)
object SomeCommand {
   val name = "ping"
   val description = "Hello"

   fun onEvent(event: NexusCommandEvent) {}
}
```

It should make the command disabled for private messages as well.